### PR TITLE
Wrap whole backlink with a class

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -216,8 +216,11 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private addBacklinks(postInfo: HTMLSpanElement, fileName: string, task: Task) {
-        postInfo.append(' (');
-        const link = postInfo.createEl('a');
+        const span = postInfo.createEl('span');
+        span.addClass('tasks-backlink');
+        span.append(' (');
+        
+        const link = span.createEl('a');
         link.href = fileName;
         link.setAttribute('data-href', fileName);
         link.rel = 'noopener';
@@ -241,6 +244,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         }
 
         link.setText(linkText);
-        postInfo.append(')');
+        
+        span.append(')');
     }
 }


### PR DESCRIPTION
I want to be able to style/replace the backlink as needed, on my summary pages I just want to restyle it with a icon like the edit button that takes you to the page it was created on but without all the space taken by the text. This is the most straight forward way I could think of as well as allowing others to style the content.